### PR TITLE
Feature/holder history

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9,8 +9,6 @@ type Token @entity {
   totalBurned: BigDecimal!
   remainingSupply: BigDecimal!
 
-  accounts: [Account!]! @derivedFrom(field: "token")
-  transfers: [Transfer!]! @derivedFrom(field: "token")
   totalHolders: BigInt!
   totalTransfers: BigInt!
   totalFees: BigDecimal!
@@ -19,16 +17,16 @@ type Token @entity {
 "Represents an account holding SIFI tokens"
 type Account @entity {
   id: ID!
-  token: Token!
+  rawBalance: BigDecimal!
   balance: BigDecimal!
 }
 
 "Represents a token transfer between SIFI accounts"
 type Transfer @entity {
   id: ID!
-  token: Token!
   transaction: Bytes!
   blockNumber: BigInt!
+  blockHash: Bytes!
   timestamp: BigInt!
   from: Bytes!
   to: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,3 +34,47 @@ type Transfer @entity {
   transferAmount: BigDecimal!
   feeAmount: BigDecimal!
 }
+
+"Represents a historic count of holders for each hour"
+type HolderHourlyData @entity {
+  id: ID!
+  timestamp: Int!
+  startBlockNumber: BigInt!
+  startCount: BigInt!
+  endCount: BigInt!
+  minCount: BigInt!
+  peakCount: BigInt!
+}
+
+"Represents a historic count of holders for each day"
+type HolderDailyData @entity {
+  id: ID!
+  timestamp: Int!
+  startBlockNumber: BigInt!
+  startCount: BigInt!
+  endCount: BigInt!
+  minCount: BigInt!
+  peakCount: BigInt!
+}
+
+"Represents a historic count of holders for each week"
+type HolderWeeklyData @entity {
+  id: ID!
+  timestamp: Int!
+  startBlockNumber: BigInt!
+  startCount: BigInt!
+  endCount: BigInt!
+  minCount: BigInt!
+  peakCount: BigInt!
+}
+
+"Represents a historic count of holders for each month"
+type HolderMonthlyData @entity {
+  id: ID!
+  timestamp: Int!
+  startBlockNumber: BigInt!
+  startCount: BigInt!
+  endCount: BigInt!
+  minCount: BigInt!
+  peakCount: BigInt!
+}

--- a/src/block.ts
+++ b/src/block.ts
@@ -1,9 +1,0 @@
-import { ethereum } from '@graphprotocol/graph-ts'
-import { updateTokenSupply } from "./token"
-import { updateAccountBalances } from "./accounts"
-
-// This is invoked every block, after all event and call handlers
-export function handleBlock(block: ethereum.Block ) : void {
-  updateTokenSupply()
-  updateAccountBalances()
-}

--- a/src/holders/holder-daily.ts
+++ b/src/holders/holder-daily.ts
@@ -1,0 +1,37 @@
+import { ethereum } from "@graphprotocol/graph-ts"
+import { Token } from "../types/schema"
+import { HolderDailyData } from '../types/schema'
+
+const ONE_DAY_SECONDS = 24 * 60 * 60
+
+/* Records daily data for holders */
+export function recordHolderDailyData(token: Token, block: ethereum.Block): HolderDailyData {
+  let timestamp = (block.timestamp.toI32() / ONE_DAY_SECONDS)
+  let id = timestamp.toString()
+  let dailyData = HolderDailyData.load(id)
+
+  // Create the daily data if it does not exist
+  if (dailyData == null) {
+    dailyData = new HolderDailyData(id)
+    dailyData.timestamp = timestamp * ONE_DAY_SECONDS
+    dailyData.startBlockNumber = block.number
+    dailyData.startCount = token.totalHolders
+    dailyData.minCount = token.totalHolders
+    dailyData.peakCount = token.totalHolders
+  }
+
+  // If current holders is below previous min, update the min value
+  if (token.totalHolders.lt(dailyData.minCount)) {
+    dailyData.minCount = token.totalHolders
+  }
+
+  // If current holders is above previous peak, update the peak value
+  if (token.totalHolders.gt(dailyData.peakCount)) {
+    dailyData.peakCount = token.totalHolders
+  }
+
+  dailyData.endCount = token.totalHolders
+  dailyData.save()
+
+  return dailyData as HolderDailyData
+}

--- a/src/holders/holder-hourly.ts
+++ b/src/holders/holder-hourly.ts
@@ -1,0 +1,37 @@
+import { ethereum } from "@graphprotocol/graph-ts"
+import { Token } from "../types/schema"
+import { HolderHourlyData } from '../types/schema'
+
+const ONE_HOUR_SECONDS = 60 * 60
+
+/* Records hourly data for holders */
+export function recordHolderHourlyData(token: Token, block: ethereum.Block): HolderHourlyData {
+  let timestamp = (block.timestamp.toI32() / ONE_HOUR_SECONDS)
+  let id = timestamp.toString()
+  let hourlyData = HolderHourlyData.load(id)
+
+  // Create the hourly data if it does not exist
+  if (hourlyData == null) {
+    hourlyData = new HolderHourlyData(id)
+    hourlyData.timestamp = timestamp * ONE_HOUR_SECONDS
+    hourlyData.startBlockNumber = block.number
+    hourlyData.startCount = token.totalHolders
+    hourlyData.minCount = token.totalHolders
+    hourlyData.peakCount = token.totalHolders
+  }
+
+  // If current holders is below previous min, update the min value
+  if (token.totalHolders.lt(hourlyData.minCount)) {
+    hourlyData.minCount = token.totalHolders
+  }
+
+  // If current holders is above previous peak, update the peak value
+  if (token.totalHolders.gt(hourlyData.peakCount)) {
+    hourlyData.peakCount = token.totalHolders
+  }
+
+  hourlyData.endCount = token.totalHolders
+  hourlyData.save()
+
+  return hourlyData as HolderHourlyData
+}

--- a/src/holders/holder-monthly.ts
+++ b/src/holders/holder-monthly.ts
@@ -1,0 +1,37 @@
+import { ethereum } from "@graphprotocol/graph-ts"
+import { Token } from "../types/schema"
+import { HolderMonthlyData } from '../types/schema'
+
+const ONE_MONTH_SECONDS = 30 * 24 * 60 * 60
+
+/* Records monthly data for holders */
+export function recordHolderMonthlyData(token: Token, block: ethereum.Block): HolderMonthlyData {
+  let timestamp = (block.timestamp.toI32() / ONE_MONTH_SECONDS)
+  let id = timestamp.toString()
+  let monthlyData = HolderMonthlyData.load(id)
+
+  // Create the monthly data if it does not exist
+  if (monthlyData == null) {
+    monthlyData = new HolderMonthlyData(id)
+    monthlyData.timestamp = timestamp * ONE_MONTH_SECONDS
+    monthlyData.startBlockNumber = block.number
+    monthlyData.startCount = token.totalHolders
+    monthlyData.minCount = token.totalHolders
+    monthlyData.peakCount = token.totalHolders
+  }
+
+  // If current holders is below previous min, update the min value
+  if (token.totalHolders.lt(monthlyData.minCount)) {
+    monthlyData.minCount = token.totalHolders
+  }
+
+  // If current holders is above previous peak, update the peak value
+  if (token.totalHolders.gt(monthlyData.peakCount)) {
+    monthlyData.peakCount = token.totalHolders
+  }
+
+  monthlyData.endCount = token.totalHolders
+  monthlyData.save()
+
+  return monthlyData as HolderMonthlyData
+}

--- a/src/holders/holder-weekly.ts
+++ b/src/holders/holder-weekly.ts
@@ -1,0 +1,37 @@
+import { ethereum } from "@graphprotocol/graph-ts"
+import { Token } from "../types/schema"
+import { HolderWeeklyData } from '../types/schema'
+
+const ONE_WEEK_SECONDS = 7 * 24 * 60 * 60
+
+/* Records weekly data for holders */
+export function recordHolderWeeklyData(token: Token, block: ethereum.Block): HolderWeeklyData {
+  let timestamp = (block.timestamp.toI32() / ONE_WEEK_SECONDS)
+  let id = timestamp.toString()
+  let weeklyData = HolderWeeklyData.load(id)
+
+  // Create the weekly data if it does not exist
+  if (weeklyData == null) {
+    weeklyData = new HolderWeeklyData(id)
+    weeklyData.timestamp = timestamp * ONE_WEEK_SECONDS
+    weeklyData.startBlockNumber = block.number
+    weeklyData.startCount = token.totalHolders
+    weeklyData.minCount = token.totalHolders
+    weeklyData.peakCount = token.totalHolders
+  }
+
+  // If current holders is below previous min, update the min value
+  if (token.totalHolders.lt(weeklyData.minCount)) {
+    weeklyData.minCount = token.totalHolders
+  }
+
+  // If current holders is above previous peak, update the peak value
+  if (token.totalHolders.gt(weeklyData.peakCount)) {
+    weeklyData.peakCount = token.totalHolders
+  }
+
+  weeklyData.endCount = token.totalHolders
+  weeklyData.save()
+
+  return weeklyData as HolderWeeklyData
+}

--- a/src/holders/index.ts
+++ b/src/holders/index.ts
@@ -1,0 +1,6 @@
+// Provides an easy re-export for these functions while keeping them in separate source files
+
+export { recordHolderHourlyData } from './holder-hourly'
+export { recordHolderDailyData } from './holder-daily'
+export { recordHolderWeeklyData } from './holder-weekly'
+export { recordHolderMonthlyData } from './holder-monthly'

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,9 +1,55 @@
-/*
- * This file serves as an index.ts to keep everything organized as separate files
- * The subgraph mapper will still see all the function handlers as top-level exports
-*/
+import { Address, ethereum } from '@graphprotocol/graph-ts'
+import { Contract, Transfer as TransferEvent } from './types/Contract/Contract'
+import { getTokenInstance } from "./token"
+import { recordTransfer } from "./transfers"
+import { updateRecipientAccount, updateSenderAccount } from "./accounts"
+import { convertTokenToDecimal } from "./helpers"
+import { BURN_ADDRESS, CONTRACT_ADDRESS, DECIMAL_ZERO, INT_ONE } from "./constants"
 
- // Re-export transfer event handlers for tracking transfers
-export { handleTransfer } from './transfers'
+// Handles a Transfer event on the contract
+export function handleTransfer(event: TransferEvent): void {
+  let token = getTokenInstance()
+  let contract = Contract.bind(Address.fromString(CONTRACT_ADDRESS))
 
-export { handleBlock } from './block'
+  // Ignore any transfers that have zero values
+  let transferAmount = convertTokenToDecimal(event.params.value)
+  if (transferAmount.le(DECIMAL_ZERO)) {
+    return
+  }
+
+  // Record the transfer and increment total count
+  let transfer = recordTransfer(event)
+  token.totalTransfers = token.totalTransfers.plus(INT_ONE)
+
+  // Update the sender and recipient balances
+  let senderSentAll = updateSenderAccount(contract, transfer.from as Address, transfer.transferAmount)
+  let isNewHolder = updateRecipientAccount(contract, transfer.to as Address, transfer.transferAmount)
+
+  // If sender now has a zero balance, decrement the holder count
+  if (senderSentAll) {
+    token.totalHolders = token.totalHolders.minus(INT_ONE)
+  }
+  // If recipient is a new account, increment the holder count
+  if (isNewHolder) {
+    token.totalHolders = token.totalHolders.plus(INT_ONE)
+  }
+
+  token.save()
+}
+
+export function handleBlock(block: ethereum.Block): void {
+  let token = getTokenInstance()
+  let contract = Contract.bind(Address.fromString(CONTRACT_ADDRESS))
+
+  // Get the amount burned
+  let burnAddress = Address.fromString(BURN_ADDRESS)
+  let totalBurned = convertTokenToDecimal(contract.balanceOf(burnAddress))
+
+  // Determine remaining supply from burned
+  token.totalBurned = totalBurned
+  token.remainingSupply = token.totalSupply.minus(totalBurned)
+
+  // Update total fees
+  token.totalFees = convertTokenToDecimal(contract.totalFees())
+  token.save()
+}

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -3,6 +3,7 @@ import { Contract, Transfer as TransferEvent } from './types/Contract/Contract'
 import { getTokenInstance } from "./token"
 import { recordTransfer } from "./transfers"
 import { updateRecipientAccount, updateSenderAccount } from "./accounts"
+import { recordHolderHourlyData, recordHolderDailyData, recordHolderWeeklyData, recordHolderMonthlyData } from "./holders"
 import { convertTokenToDecimal } from "./helpers"
 import { BURN_ADDRESS, CONTRACT_ADDRESS, DECIMAL_ZERO, INT_ONE } from "./constants"
 
@@ -47,6 +48,11 @@ export function handleTransfer(event: TransferEvent): void {
 
 /* Gets called every block */
 export function handleBlock(block: ethereum.Block): void {
-  // let token = getTokenInstance()
+  let token = getTokenInstance()
   // let contract = Contract.bind(Address.fromString(CONTRACT_ADDRESS))
+
+  // Record holder historic data
+  recordHolderHourlyData(token, block)
+  recordHolderDailyData(token, block)
+  recordHolderWeeklyData(token, block)
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -2,7 +2,7 @@ import { Address } from '@graphprotocol/graph-ts'
 import { Contract } from './types/Contract/Contract'
 import { Token } from './types/schema'
 import { convertTokenToDecimal } from "./helpers"
-import { BURN_ADDRESS, CONTRACT_ADDRESS, DECIMAL_ZERO, INT_ZERO } from "./constants"
+import { CONTRACT_ADDRESS, DECIMAL_ZERO, INT_ZERO } from "./constants"
 
 // Gets the singleton instance of the token entity
 export function getTokenInstance() : Token {
@@ -27,21 +27,4 @@ export function getTokenInstance() : Token {
   }
 
   return token as Token
-}
-
-export function updateTokenSupply() : void {
-  let contract = Contract.bind(Address.fromString(CONTRACT_ADDRESS))
-  let token = getTokenInstance()
-
-  // Get the amount burned
-  let burnAddress = Address.fromString(BURN_ADDRESS)
-  let totalBurned = convertTokenToDecimal(contract.balanceOf(burnAddress))
-
-  // Determine remaining supply from burned
-  token.totalBurned = totalBurned
-  token.remainingSupply = token.totalSupply.minus(totalBurned)
-
-  // Update total fees
-  token.totalFees = convertTokenToDecimal(contract.totalFees())
-  token.save()
 }

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -1,41 +1,29 @@
-import { Address, BigDecimal } from "@graphprotocol/graph-ts"
-import { Contract, Transfer as TransferEvent } from './types/Contract/Contract'
+import { BigDecimal } from "@graphprotocol/graph-ts"
+import { Transfer as TransferEvent } from './types/Contract/Contract'
 import { Transfer } from './types/schema'
-import { getTokenInstance } from "./token"
-import { updateRecipientAccount, updateSenderAccount } from "./accounts"
 import { convertTokenToDecimal } from "./helpers"
-import { INT_ONE } from "./constants"
 
 let NINETY_FIVE_PERCENT = BigDecimal.fromString("0.95")
 let FIVE_PERCENT = BigDecimal.fromString("0.05")
 
-// Handles a Transfer event from the token contract
-export function handleTransfer(event: TransferEvent) : void {
-  // Bind the contract to the address that emitted the event
-  let contract = Contract.bind(event.address)
-
+/* Records the transfer as a graph entity and returns it */
+export function recordTransfer(event: TransferEvent): Transfer {
   // The ID will be the transaction hash since that is likely unique to each transfer
   let id = event.transaction.hash.toHexString()
 
+  // Create transfer if it does not exist already
   let transfer = Transfer.load(id)
   if (transfer == null) {
-    let token = getTokenInstance()
-
-    // Create new transfer
     transfer = new Transfer(id)
-    transfer.token = token.id
-
-    // Increment total transfer count
-    token.totalTransfers = token.totalTransfers.plus(INT_ONE)
-    token.save()
   }
 
-  // Set transaction info
+  // Set transaction and block metadata
   transfer.transaction = event.transaction.hash
   transfer.blockNumber = event.block.number
+  transfer.blockHash = event.block.hash
   transfer.timestamp = event.block.timestamp
 
-  // Get sender, recipient, and transferred amount from event
+  // Get the sender, recipient, and amount transferred
   transfer.from = event.params.from
   transfer.to = event.params.to
   transfer.transferAmount = convertTokenToDecimal(event.params.value)
@@ -45,7 +33,5 @@ export function handleTransfer(event: TransferEvent) : void {
   transfer.feeAmount = transfer.amount.times(FIVE_PERCENT)
 
   transfer.save()
-
-  updateSenderAccount(contract, transfer.from as Address, transfer.transferAmount)
-  updateRecipientAccount(contract, transfer.to as Address, transfer.transferAmount)
+  return transfer as Transfer
 }


### PR DESCRIPTION
This adds several entities which tracks the number of holders over time. This is updated once per block:

- `HolderHourlyData` -- start/end/min/peak of holders within an hour
- `HolderDailyData` -- start/end/min/peak of holders within an day
- `HolderWeeklyData` -- start/end/min/peak of holders within a week
- `HolderMonthlyData` -- start/end/min/peak of holders within a monthly

Each of these also have a `timestamp` of when the period started, along with `startBlockNumber` for reference.